### PR TITLE
Minor grammatical changes

### DIFF
--- a/binder/PyData22_deblurring.ipynb
+++ b/binder/PyData22_deblurring.ipynb
@@ -5,7 +5,7 @@
    "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
    "metadata": {},
    "source": [
-    "# Demo 1: Deblurring as example of inverse problems in CIL"
+    "# Demo 1: Deblurring as an example of inverse problems in CIL"
    ]
   },
   {
@@ -41,8 +41,7 @@
     "from cil.utilities.display import show2D\n",
     "\n",
     "# Third-party\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import numpy as np"
    ]
   },
   {
@@ -58,7 +57,7 @@
    "id": "de100599-7643-442e-8e46-c2122beb05f1",
    "metadata": {},
    "source": [
-    "CIL comes a number of test images such as\n",
+    "CIL comes with a number of test images such as\n",
     "- `BOAT`\n",
     "- `CAMERA`\n",
     "- `PEPPERS`(color)\n",
@@ -218,7 +217,7 @@
    "id": "64deaef0-c87f-48ce-a238-9b1e8508e612",
    "metadata": {},
    "source": [
-    "We finally some Gaussian noise to the blurred image:"
+    "We finally add some Gaussian noise to the blurred image:"
    ]
   },
   {


### PR DESCRIPTION
Some small changes to the wording.
I also removed: `import matplotlib.pyplot as plt` as I could not see that it was used anywhere?