### PR TITLE
Fix display of noisy sinogram in 04_FBP_CGLS_SIRT.ipynb

### DIFF
--- a/training/2021_Fully3D/Week1/04_FBP_CGLS_SIRT.ipynb
+++ b/training/2021_Fully3D/Week1/04_FBP_CGLS_SIRT.ipynb
@@ -434,7 +434,7 @@
    "outputs": [],
    "source": [
     "# visualise results\n",
-    "show2D([sino, sino], ['ground truth sinogram', 'noisy sinogram'], \\\n",
+    "show2D([sino, sino_noisy], ['ground truth sinogram', 'noisy sinogram'], \\\n",
     "       cmap=cmap, num_cols=2, size=(15,10), origin='upper-left')"
    ]
   },


### PR DESCRIPTION
Here it is meant to compare the normal and noisy sinograms. Instead, it was displaying the same sinogram twice.