### PR TITLE
Fixed broken link in exercise notebook3

### DIFF
--- a/demos/1_Introduction/exercises/03_where_is_my_reader.ipynb
+++ b/demos/1_Introduction/exercises/03_where_is_my_reader.ipynb
@@ -282,7 +282,7 @@
     "\n",
     "Now we create the CIL `AcquisitionGeometry` object using the method `AcquisitionGeometry.create_Cone2D`\n",
     "\n",
-    "You will have to set the position of the source, rotation axis (object) and detector. Look at the [documentation of `create_Cone2D`](https://tomographicimaging.github.io/CIL/nightly/framework.html#cone2d-geometry-fanbeam) as well as the notebook [00_CIL_geometry](../00_CIL_geometry.ipynb) to help you.\n",
+    "You will have to set the position of the source, rotation axis (object) and detector. Look at the [documentation of `create_Cone2D`](https://tomographicimaging.github.io/CIL/nightly/framework/#cone2d-geometry-fanbeam) as well as the notebook [00_CIL_geometry](../00_CIL_geometry.ipynb) to help you.\n",
     "\n",
     "1. Create a fan-beam geometry using the `AcquisitionGeometry.create_Cone2D`\n",
     "2. Configure the angles of the data with `set_angles`\n",

--- a/demos/1_Introduction/exercises/03_where_is_my_reader.ipynb
+++ b/demos/1_Introduction/exercises/03_where_is_my_reader.ipynb
@@ -24,6 +24,7 @@
     "#\n",
     "#   Authored by:    Gemma Fardell (UKRI-STFC)\n",
     "#                   Laura Murgatroyd (UKRI-STFC)\n",
+    "#                   Rasmia Kulan (UKRI-STFC)\n",
     "                  "
    ]
   },
@@ -179,7 +180,7 @@
    "source": [
     "We should notice that the data is X-ray transmission data. We can see that the background peak has the highest value.\n",
     "\n",
-    "The background peak is not at 1. When the data was saved as a tiff it was pre-scaled by 60000 by the scanner and stored as `unsigned char` which have integer values 0 - 65535. We can see the white level of 60000 in the `xtek2dct` file so we use this to normalise the data.  If you would like to view the `xtek2dct` open a terminal and type the command `cat /mnt/materials/CIL/SparseBeads_B12_L1/CentreSlice/SparseBeads_B12_L1.xtek2dct`\n"
+    "The background peak is not at 1. When the data was saved as a tiff it was pre-scaled by 60000 by the scanner and stored as `unsigned short` which have integer values 0 - 65535. We can see the white level of 60000 in the `xtek2dct` file so we use this to normalise the data.  If you would like to view the `xtek2dct` open a terminal and type the command `cat /mnt/materials/CIL/SparseBeads_B12_L1/CentreSlice/SparseBeads_B12_L1.xtek2dct`\n"
    ]
   },
   {


### PR DESCRIPTION
Closes #145 

- Updated the link in the documentation for exercise  `03_where_is_my_reader` to direct to the right URL. 
- Added another author
- Replace char with short in `Understand your data` description