### PR TITLE
swap `islicer` and TransmissionAbsorptionConverter cells

### DIFF
--- a/demos/1_Introduction/01_intro_walnut_conebeam.ipynb
+++ b/demos/1_Introduction/01_intro_walnut_conebeam.ipynb
@@ -231,7 +231,7 @@
    "id": "4d3fd724",
    "metadata": {},
    "source": [
-    "We can also use a basic interactive viewer which will allow us to scroll through the various projections. [`islicer`](https://tomographicimaging.github.io/CIL/nightly/utilities.html#islicer-interactive-display-of-2d-slices) has a very similar interface to [`show2D`](https://tomographicimaging.github.io/CIL/nightly/utilities.html#show2d-display-2d-slices), but not quite the same."
+    "From the background value of 1.0 we infer that the data is transmission data (it is known to be already centered and flat field corrected) so we just need to convert to absorption/apply the negative logarithm, which can be done using a CIL processor, which will handle small/large outliers:"
    ]
   },
   {
@@ -241,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "islicer(data)"
+    "data = TransmissionAbsorptionConverter()(data)"
    ]
   },
   {
@@ -249,7 +249,7 @@
    "id": "4880c37b",
    "metadata": {},
    "source": [
-    "From the background value of 1.0 we infer that the data is transmission data (it is known to be already centered and flat field corrected) so we just need to convert to absorption/apply the negative logarithm, which can be done using a CIL processor, which will handle small/large outliers:"
+    "We can also use a basic interactive viewer which will allow us to scroll through the various projections. [`islicer`](https://tomographicimaging.github.io/CIL/nightly/utilities.html#islicer-interactive-display-of-2d-slices) has a very similar interface to [`show2D`](https://tomographicimaging.github.io/CIL/nightly/utilities.html#show2d-display-2d-slices), but not quite the same."
    ]
   },
   {
@@ -259,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = TransmissionAbsorptionConverter()(data)"
+    "islicer(data)"
    ]
   },
   {


### PR DESCRIPTION
Due to https://github.com/TomographicImaging/CIL/issues/1953 we need to be a bit more careful using `islicer`.

Here I propose to use `islicer` only after having run the `TransmissionAbsorptionConverter` step that'll keep memory usage under control.