### PR TITLE
V24.3.0 folder 2 updates

### DIFF
--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -26,7 +26,8 @@
     "#   Authored by:    Jakob S. Jørgensen (DTU)\n",
     "#                   Gemma Fardell (UKRI-STFC)     \n",
     "#                   Laura Murgatroyd (UKRI-STFC)\n",
-    "#                   Margaret Duff (UKRI-STFC)     "
+    "#                   Margaret Duff (UKRI-STFC)\n",
+    "#                   Hannah Robarts (UKRI-STFC)"
    ]
   },
   {
@@ -55,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +67,7 @@
     "                                       GradientOperator\n",
     "from cil.optimisation.functions import IndicatorBox, MixedL21Norm, L2NormSquared, \\\n",
     "                                       BlockFunction, L1Norm, LeastSquares, \\\n",
-    "                                       OperatorCompositionFunction, TotalVariation, \\\n",
+    "                                       OperatorCompositionFunction, TotalVariation \\\n",
     "\n",
     "# Import CIL Processors for preprocessing\n",
     "from cil.processors import CentreOfRotationCorrector, Slicer, TransmissionAbsorptionConverter\n",

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,10 @@
     "\n",
     "# All external imports\n",
     "import matplotlib.pyplot as plt\n",
-    "import math"
+    "import math\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)"
    ]
   },
   {
@@ -948,7 +951,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cil_24.2",
+   "display_name": "cil_demos",
    "language": "python",
    "name": "python3"
   },
@@ -962,7 +965,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,11 +621,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load 'snippets/01_ex1_a.py'"
+    "# %load 'snippets/01_ex1_a.py'\n",
+    "alpha = 30\n",
+    "G = alpha*L1Norm()\n",
+    "F = LeastSquares(A, b)\n",
+    "\n",
+    "myFISTAL1 = FISTA(f=F, \n",
+    "                  g=G, \n",
+    "                  initial=x0, \n",
+    "                  update_objective_interval=10)"
    ]
   },
   {
@@ -650,7 +658,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load 'snippets/01_ex1_b.py'"
+    "# %load 'snippets/01_ex1_b.py'\n",
+    "myFISTAL1.run(300,verbose=1)"
    ]
   },
   {
@@ -711,11 +720,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load snippets/01_ex2.py"
+    "# %load snippets/01_ex2.py\n",
+    "# Run 200 iterations of `myFISTATV` with:\n",
+    "alpha=0.02"
    ]
   },
   {
@@ -822,7 +833,8 @@
     "myPDHG = PDHG(f=F, \n",
     "              g=G, \n",
     "              operator=K, \n",
-    "              update_objective_interval = 10)"
+    "              update_objective_interval = 10,\n",
+    "              check_convergence = False)"
    ]
   },
   {

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
    "source": [
     "To set up the gradient descent algorithm, we specify:\n",
     " - `initial` - the initial point \n",
-    " - `objective_function` - the objective function\n",
+    " - `f` - the objective function\n",
     " - `step_size` - whether to use a fixed step size or a back-tracking line search (None) or  a function that takes the initialised algorithm and returns a step size which can vary e.g. on objective value or iteration number. For more information see: https://tomographicimaging.github.io/CIL/nightly/optimisation/#step-size-methods. \n",
     " - `update_objective_interval` - how often to evaluate the objective function value\n",
     " - `preconditioner` (optional) a functional that takes a calculated gradient and the initialised algorithm and *preconditions* the gradient, e.g. multiplies it by a matrix to provide a (hopefully) more effective descent direction. For more information see, https://tomographicimaging.github.io/CIL/nightly/optimisation/#preconditioners. \n",
@@ -324,12 +324,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
     "myGD_LS = GD(initial=x0, \n",
-    "             objective_function=f1, \n",
+    "             f=f1, \n",
     "             step_size=None, \n",
     "             update_objective_interval=10)"
    ]
@@ -458,7 +458,7 @@
    "outputs": [],
    "source": [
     "myGD_tikh = GD(initial=x0, \n",
-    "               objective_function=f, \n",
+    "               f=f, \n",
     "               step_size=1/f.L, \n",
     "               update_objective_interval = 10)"
    ]

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,6 @@
     "from cil.optimisation.functions import IndicatorBox, MixedL21Norm, L2NormSquared, \\\n",
     "                                       BlockFunction, L1Norm, LeastSquares, \\\n",
     "                                       OperatorCompositionFunction, TotalVariation, \\\n",
-    "                                       ZeroFunction\n",
     "\n",
     "# Import CIL Processors for preprocessing\n",
     "from cil.processors import CentreOfRotationCorrector, Slicer, TransmissionAbsorptionConverter\n",
@@ -108,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,19 +620,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load 'snippets/01_ex1_a.py'\n",
-    "alpha = 30\n",
-    "G = alpha*L1Norm()\n",
-    "F = LeastSquares(A, b)\n",
-    "\n",
-    "myFISTAL1 = FISTA(f=F, \n",
-    "                  g=G, \n",
-    "                  initial=x0, \n",
-    "                  update_objective_interval=10)"
+    "# %load 'snippets/01_ex1_a.py'"
    ]
   },
   {
@@ -658,8 +649,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load 'snippets/01_ex1_b.py'\n",
-    "myFISTAL1.run(300,verbose=1)"
+    "# %load 'snippets/01_ex1_b.py'"
    ]
   },
   {
@@ -720,22 +710,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load snippets/01_ex2.py\n",
-    "# Run 200 iterations of `myFISTATV` with:\n",
-    "alpha=0.02"
+    "# %load snippets/01_ex2.py"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
-    "GTV = alpha*FGP_TV(device='gpu') \n",
+    "GTV = alpha*FGP_TV(device='gpu', nonnegativity=True) \n",
     "myFISTATV = FISTA(f=F, \n",
     "                  g=GTV, \n",
     "                  initial=x0 ,\n",
@@ -780,14 +768,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "markdown"
-    }
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We can see that TV-regularisation successfully compensates for the streak artifacts caused by few projections, suppresses noise and preserves sharp edges in the reconstruction."
    ]
@@ -820,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -829,7 +811,7 @@
     "                  alpha*MixedL21Norm())\n",
     "K = BlockOperator(A, \n",
     "                  D)\n",
-    "G = ZeroFunction()\n",
+    "G = IndicatorBox(lower=0.0)\n",
     "myPDHG = PDHG(f=F, \n",
     "              g=G, \n",
     "              operator=K, \n",
@@ -843,7 +825,7 @@
    "source": [
     "Run the algorithm for a specified number of iterations with increased verbosity/amount of printing to screen.\n",
     "\n",
-    "Here we initially run for 500 iterations."
+    "Here we run for 500 iterations."
    ]
   },
   {
@@ -859,8 +841,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, this will not be enough iterations for the solution to match the FISTA solution.\n",
-    "\n",
     "Show the TV-regularised solution obtained by the PDHG Algorithm:"
    ]
   },
@@ -895,12 +875,11 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.loglog(myFISTATV.iterations[1:], myFISTATV.objective[1:])\n",
     "plt.loglog(myPDHG.iterations[1:], myPDHG.objective[1:])\n",
     "plt.loglog(myPDHG.iterations[1:], myPDHG.dual_objective[1:])\n",
     "plt.loglog(myPDHG.iterations[1:], myPDHG.primal_dual_gap[1:])\n",
-    "plt.ylim((1e0,1e5))\n",
-    "plt.legend(['FISTA','PDHG primal','PDHG dual','PDHG gap'])\n",
+    "plt.ylim((1e0,1e4))\n",
+    "plt.legend(['PDHG primal','PDHG dual','PDHG gap'])\n",
     "plt.grid()\n",
     "plt.xlabel('Number of iterations')\n",
     "plt.ylabel('Objective value')"
@@ -910,9 +889,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We observe that the two algorithms achieve approximately the same (primal) objective value. PDHG in addition supplies the dual objective, and the primal-dual gap (difference of primal of dual objectives) which helps for monitoring convergence. This primal-dual gap tends to zero as the algorithm approaches the solution. \n",
+    "PDHG supplies the primal objective, the dual objective, and the primal-dual gap (difference of primal of dual objectives) which helps for monitoring convergence. We see that the primal-dual gap is tending towards zero as the algorithm approaches the solution. \n",
     "\n",
-    "Although in practice fewer iterations are often sufficient for a visually converged image to see a very well converged primal-dual gap we want to run for more iterations. It will take approximately 5 minutes to run an additional 4500 iterations."
+    "Although in practice fewer iterations are often sufficient for a visually converged image to see a very well converged primal-dual gap we want to run for more iterations. It will take a few minutes to run an additional 500 iterations."
    ]
   },
   {
@@ -921,8 +900,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "myPDHG.update_objective_interval = 100\n",
-    "myPDHG.run(4500,verbose=2)"
+    "myPDHG.run(500,verbose=2)"
    ]
   },
   {
@@ -939,7 +917,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now see the resulting image matches the FISTA solution."
+    "We can now see the resulting image matches the FISTA solution, and plotting the conververgence we observe that the two algorithms achieve approximately the same (primal) objective value."
    ]
   },
   {
@@ -951,10 +929,7 @@
     "plt.figure()\n",
     "plt.loglog(myFISTATV.iterations[1:], myFISTATV.objective[1:])\n",
     "plt.loglog(myPDHG.iterations[1:], myPDHG.objective[1:])\n",
-    "plt.loglog(myPDHG.iterations[1:], myPDHG.dual_objective[1:])\n",
-    "plt.loglog(myPDHG.iterations[1:], myPDHG.primal_dual_gap[1:])\n",
-    "plt.ylim((1e0,1e5))\n",
-    "plt.legend(['FISTA','PDHG primal','PDHG dual','PDHG gap'])\n",
+    "plt.legend(['FISTA','PDHG primal'])\n",
     "plt.grid()\n",
     "plt.xlabel('Number of iterations')\n",
     "plt.ylabel('Objective value')"

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -892,7 +892,7 @@
    "source": [
     "PDHG supplies the primal objective, the dual objective, and the primal-dual gap (difference of primal of dual objectives) which helps for monitoring convergence. We see that the primal-dual gap is tending towards zero as the algorithm approaches the solution. \n",
     "\n",
-    "Although in practice fewer iterations are often sufficient for a visually converged image to see a very well converged primal-dual gap we want to run for more iterations. It will take a few minutes to run an additional 500 iterations."
+    "To have a well-converged primal-dual gap, we want to run for more iterations, in this case, another 500 iterations. In practice, we often see a visually converged image in fewer iterations.  "
    ]
   },
   {
@@ -918,7 +918,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now see the resulting image matches the FISTA solution, and plotting the conververgence we observe that the two algorithms achieve approximately the same (primal) objective value."
+    "We see the resulting image matches the FISTA solution, and plotting the conververgence we observe that the two algorithms achieve approximately the same (primal) objective value."
    ]
   },
   {

--- a/demos/2_Iterative/01_optimisation_gd_fista.ipynb
+++ b/demos/2_Iterative/01_optimisation_gd_fista.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/demos/2_Iterative/02_tikhonov_block_framework.ipynb
+++ b/demos/2_Iterative/02_tikhonov_block_framework.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "skip"
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "skip"
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -567,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -590,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
@@ -835,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1079,7 +1079,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,7 +1113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"

--- a/demos/2_Iterative/02_tikhonov_block_framework.ipynb
+++ b/demos/2_Iterative/02_tikhonov_block_framework.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "slideshow": {
      "slide_type": "skip"
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "slideshow": {
      "slide_type": "skip"
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -430,8 +430,8 @@
    "outputs": [],
    "source": [
     "show1D([phantom2D, cgls_simple.solution],\n",
-    "       slice_list=[(\"horizontal_y\",n/2)],\n",
-    "       label=[\"Ground Truth\",\"CGLS\"],\n",
+    "       slice_list=[(\"horizontal_y\",int(n/2))],\n",
+    "       dataset_labels=[\"Ground Truth\",\"CGLS\"],\n",
     "       line_colours=['black','dodgerblue'],\n",
     "       line_styles=['solid','dashed'])"
    ]
@@ -567,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -590,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
@@ -696,8 +696,8 @@
    "outputs": [],
    "source": [
     "show1D([phantom2D, cgls_simple.solution, cgls_tikh.solution],\n",
-    "       slice_list=[(\"horizontal_y\",n/2)],\n",
-    "       label=[\"Ground Truth\",\"CGLS\",\"Tikhonov with Identity regularisation\"],\n",
+    "       slice_list=[(\"horizontal_y\", int(n/2))],\n",
+    "       dataset_labels=[\"Ground Truth\",\"CGLS\",\"Tikhonov with Identity regularisation\"],\n",
     "       line_colours=['black','dodgerblue','firebrick'],\n",
     "       line_styles=['solid','dashed','dotted'])"
    ]
@@ -835,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1079,7 +1079,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,7 +1113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
@@ -1172,8 +1172,8 @@
    "outputs": [],
    "source": [
     "show1D([phantom2D, cgls_tikh_g.solution],\n",
-    "       slice_list=[(\"horizontal_y\",n/2)],\n",
-    "       label=[\"Ground Truth\",\"Tikhonov with Gradient regularisation\"], \n",
+    "       slice_list=[(\"horizontal_y\",int(n/2))],\n",
+    "       dataset_labels=[\"Ground Truth\",\"Tikhonov with Gradient regularisation\"], \n",
     "       line_colours=['black','purple'],\n",
     "       line_styles=['solid','solid'])"
    ]
@@ -1218,8 +1218,8 @@
    "outputs": [],
    "source": [
     "show1D([phantom2D, cgls_simple.solution, cgls_tikh.solution, cgls_tikh_g.solution],\n",
-    "       slice_list=[(\"horizontal_y\",n/2)],\n",
-    "       label=[\"Ground Truth\",\"CGLS\",\"Tikhonov with Identity regularisation\", \"Tikhonov with Gradient regularisation\"],\n",
+    "       slice_list=[(\"horizontal_y\",int(n/2))],\n",
+    "       dataset_labels=[\"Ground Truth\",\"CGLS\",\"Tikhonov with Identity regularisation\", \"Tikhonov with Gradient regularisation\"],\n",
     "       line_colours=['black','dodgerblue','firebrick','purple'],\n",
     "       line_styles=['solid','dashed','dotted','solid'])"
    ]
@@ -1255,7 +1255,7 @@
  "metadata": {
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cil_demos",
    "language": "python",
    "name": "python3"
   },
@@ -1269,12 +1269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "cf07678abc5cc77bc6e1a7d19b1e87ab0c29b83e7ee41c2bc72506d16d80ed44"
-   }
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/02_tikhonov_block_framework.ipynb
+++ b/demos/2_Iterative/02_tikhonov_block_framework.ipynb
@@ -29,7 +29,8 @@
     "#\n",
     "#   Authored by:    Jakob S. Jørgensen (DTU)\n",
     "#                   Gemma Fardell (UKRI-STFC)\n",
-    "#                   Margaret Duff (UKRI-STFC)     "
+    "#                   Margaret Duff (UKRI-STFC)\n",
+    "#                   Hannah Robarts (UKRI-STFC)"
    ]
   },
   {

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3",
    "metadata": {},
    "outputs": [],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "6",
    "metadata": {},
    "outputs": [],
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "7",
    "metadata": {},
    "outputs": [],
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "8",
    "metadata": {},
    "outputs": [],
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "16",
    "metadata": {},
    "outputs": [],
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "18",
    "metadata": {},
    "outputs": [],
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "19",
    "metadata": {},
    "outputs": [],
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "22",
    "metadata": {},
    "outputs": [],
@@ -645,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "34",
    "metadata": {},
    "outputs": [],
@@ -904,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "46",
    "metadata": {},
    "outputs": [],
@@ -1000,7 +1000,7 @@
     "# Setup and run PDHG\n",
     "pdhg_tv_implicit_regtk = PDHG(f = F, g = G, operator = K,\n",
     "            update_objective_interval = 200)\n",
-    "pdhg_tv_implicit_regtk.run(1000, verbose=1)"
+    "pdhg_tv_implicit_regtk.run(1000, verbose=1, check_convergence=False)"
    ]
   },
   {
@@ -1015,7 +1015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "53",
    "metadata": {},
    "outputs": [],
@@ -1048,7 +1048,7 @@
    "id": "55",
    "metadata": {},
    "source": [
-    "In the above comparison between explicit and implicit TV reconstructions, we may observe some differences in the reconstructions and in the middle line profiles. This is due to a) the number of iterations and b) $\\sigma, \\tau$ values used in both the explicit and implicit setup of the PDHG algorithm. You can try more iterations with different values of $\\sigma$ and $\\tau$ for both cases in order to be sure that converge to the same solution."
+    "In the above comparison between explicit and implicit TV reconstructions, we may observe some small differences in the reconstructions and in the middle line profiles. This is due to a) the number of iterations and b) $\\sigma, \\tau$ values used in both the explicit and implicit setup of the PDHG algorithm. You can try more iterations with different values of $\\sigma$ and $\\tau$ for both cases in order to be sure that converge to the same solution."
    ]
   },
   {
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "60",
    "metadata": {},
    "outputs": [],
@@ -1215,7 +1215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"/mnt/share/materials/SIRF/Fully3D/CIL/Walnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm\""
+    "filename = \"/mnt/materials/SIRF/Fully3D/CIL/Walnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm\""
    ]
   },
   {
@@ -501,24 +501,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex1.py\n",
-    "# Setup and run the FBP algorithm\n",
-    "fbp_recon = FBP(ig2D, ag2D,  device = 'gpu')(absorption_data)\n",
-    "\n",
-    "# Setup and run the SIRT algorithm, with  non-negative constraint\n",
-    "x_init = ig2D.allocate()  \n",
-    "sirt = SIRT(initial = x_init, \n",
-    "            operator = A ,\n",
-    "            data = absorption_data, \n",
-    "            constraint = IndicatorBox(lower=0),\n",
-    "            update_objective_interval=100)\n",
-    "sirt.run(300, verbose=1)\n",
-    "sirt_recon = sirt.solution\n",
-    "\n",
-    "# Show reconstructions\n",
-    "show2D([fbp_recon,sirt_recon], \n",
-    "       title = ['FBP reconstruction','SIRT reconstruction'], \n",
-    "       cmap = 'inferno', fix_range=(0,0.05))"
+    "# %load ./snippets/03_ex1.py"
    ]
   },
   {
@@ -921,21 +904,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "7340eadf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex2.py\n",
-    "# Define BlockFunction F\n",
-    "alpha_tikhonov = 0.05\n",
-    "f1 = alpha_tikhonov * L2NormSquared()\n",
-    "F = BlockFunction(f1, f2)\n",
-    "\n",
-    "# Setup and run PDHG\n",
-    "pdhg_tikhonov_explicit = PDHG(f = F, g = G, operator = K,\n",
-    "            update_objective_interval = 200)\n",
-    "pdhg_tikhonov_explicit.run(1000, verbose=1)"
+    "# %load ./snippets/03_ex2.py"
    ]
   },
   {
@@ -1046,15 +1020,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex3.py\n",
-    "F = 0.5 * L2NormSquared(b=absorption_data)\n",
-    "G = (alpha_tv/ig2D.voxel_size_y) * FGP_TV(max_iteration=100, device='gpu')\n",
-    "K = A\n",
-    "\n",
-    "# Setup and run PDHG\n",
-    "pdhg_tv_implicit_regtk = PDHG(f = F, g = G, operator = K,\n",
-    "            update_objective_interval = 200, check_convergence = False)\n",
-    "pdhg_tv_implicit_regtk.run(1000, verbose=1)"
+    "# %load ./snippets/03_ex3.py"
    ]
   },
   {

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "d304d2b3",
+   "execution_count": null,
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "c06fd185-0bbb-48c1-ba6c-ac61cad8266b",
+   "id": "1",
    "metadata": {},
    "source": [
     "# Primal Dual Hybrid Gradient Algorithm\n",
@@ -80,7 +80,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "385c848a-9d9a-48ff-b029-a42e90e4cb2c",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Learning objectives\n",
@@ -138,8 +138,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "f731d970-d6ce-489a-bf93-7888cc855a60",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36dc5a6d-c4e9-4ece-9f37-cde82dc93964",
+   "id": "4",
    "metadata": {},
    "source": [
     "# Data information\n",
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "732c5f6b-6fd4-43ea-b5f6-796632f62528",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Load walnut data"
@@ -196,8 +196,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "ce2c36aa-1231-4669-9486-197f9332fe2e",
+   "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d64a1b3a",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,8 +216,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "0fd50459",
+   "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f97e39e-12db-4eae-9de5-cc31e667490e",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Acquisition and Image geometry information"
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ece32bb6-5066-4f7c-b6b6-8edc62ecb817",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14083f74-3490-4d18-a784-c659f2c5984b",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bab54a03-3ab6-4100-a82a-45a8e807e5f1",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Show Acquisition geometry and full 3D sinogram."
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6b6a162-08d5-4c28-9a2b-a06091747f0a",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc29dd0a-2f27-4a89-8a49-9733d9453b86",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc945eb5-17d9-476e-b4dd-998b9b90d51e",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Slice through projections\n",
@@ -295,8 +295,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "e6e19c5d-0724-46a2-907c-d9e86b24ee91",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5afa53ea-6723-44ef-a803-587630568ec4",
+   "id": "17",
    "metadata": {},
    "source": [
     "### For demonstration purposes, we extract the central slice and select only 160 angles from the total 1601 angles.\n",
@@ -319,8 +319,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "3dae73ff-165f-4ac3-990a-e5584a627e9f",
+   "execution_count": null,
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,8 +348,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "4165bcfc-1e28-44ea-bfe3-f85648bc4dc8",
+   "execution_count": null,
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fdafdab-19f2-499a-8b6b-acfdaa83bf95",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3156de74-773a-4ec9-aadb-1f7d31a435b5",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Define Projection Operator \n",
@@ -381,8 +381,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "e4919986-1aad-4e2d-9af3-68d7b1d685ea",
+   "execution_count": null,
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3e9e994-a8f8-4877-b366-789989760f8a",
+   "id": "23",
    "metadata": {},
    "source": [
     "## FBP and SIRT reconstructions\n",
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b912854b-d7bc-49d4-8aa0-fa6f563c5d72",
+   "id": "24",
    "metadata": {},
    "source": [
     "For SIRT, we type\n",
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54097efa-1fec-44cb-bc12-18fbf6d8d797",
+   "id": "25",
    "metadata": {},
    "source": [
     "### **Exercise 1: Run FBP and SIRT reconstructions**\n",
@@ -461,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcb5e5c1-21d2-4210-982d-3ee87da6892c",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62c95c5d",
+   "id": "27",
    "metadata": {},
    "source": [
     "### **Exercise 1: Solution**\n",
@@ -497,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e348820",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +507,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "024626bc-bc07-4f65-9b7e-7641c7c19528",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Why PDHG?\n",
@@ -543,7 +543,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29699f88-da86-4be7-9145-9d9ff51198fc",
+   "id": "30",
    "metadata": {},
    "source": [
     "### $L^{1}$ regularisation\n",
@@ -563,7 +563,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5a99548-d786-4dd6-87b8-6301d27c0989",
+   "id": "31",
    "metadata": {},
    "source": [
     "## How to setup and run PDHG?\n",
@@ -606,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e3a6b63-c855-4094-9e7d-2a20c06d762f",
+   "id": "32",
    "metadata": {},
    "source": [
     "The algorithm is described in the [Appendix](../appendix.ipynb) and for every iteration, we solve two (proximal-type) subproblems, i.e., __primal & dual problems__ where \n",
@@ -636,7 +636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d18293aa-19d0-435f-8aca-1f9575131d03",
+   "id": "33",
    "metadata": {},
    "source": [
     "<a id='sigma_tau'></a>\n",
@@ -645,8 +645,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "b2879663-a0fe-4a3f-900f-c2cd8ba31226",
+   "execution_count": null,
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96234d76-14d3-4f7c-961c-8c717fb531d7",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Setup and run PDHG"
@@ -667,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85ff3e81-2ed1-4aee-a97f-051fe4ad5580",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0d969cd-225a-47cf-af38-0a2be75965c6",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c695cd3f-a612-4bbe-99d2-ee2e9dd033b8",
+   "id": "38",
    "metadata": {},
    "source": [
     "# PDHG for Total Variation Regularisation\n",
@@ -779,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33dc3542-e984-4eeb-9e12-1abadedfc9a4",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af31caee-4684-49ad-bcf0-0ff05221a5da",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26da6bf7",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Speed of PDHG convergence"
@@ -828,7 +828,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1154a706-45f5-406c-b9b5-080e0083cb8c",
+   "id": "42",
    "metadata": {},
    "source": [
     "The PDHG algorithm converges when $\\sigma\\tau\\|K\\|^{2}<1$, where the variable $\\sigma$, $\\tau$ are called the _primal and dual stepsizes_. When we setup the PDHG algorithm, the default values of $\\sigma$ and $\\tau$ are used:\n",
@@ -864,7 +864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb5d3a68-4c1c-45c6-9304-072f5d1e55ad",
+   "id": "43",
    "metadata": {},
    "source": [
     "## **Exercise 2: Setup and run PDHG algorithm for Tikhonov regularisation**\n",
@@ -877,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90129b41-48eb-4487-b2a0-cdc2df1c70ee",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bf82bca",
+   "id": "45",
    "metadata": {},
    "source": [
     "## **Exercise 2: Solution**\n",
@@ -904,8 +904,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "7340eadf",
+   "execution_count": null,
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,7 +915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "960b7f91-b6ae-419f-b5ed-40f369a496db",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78c4bcbc-f3a5-4cb6-b388-8c3cb294070a",
+   "id": "48",
    "metadata": {},
    "source": [
     "---\n",
@@ -963,7 +963,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d32911d-b3d5-495f-a787-9aac95492efb",
+   "id": "49",
    "metadata": {},
    "source": [
     "## **Exercise 3: Setup and run implicit PDHG algorithm with the Total variation regulariser**\n",
@@ -980,7 +980,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0c70da8-a069-4df2-b946-6a5900ad8794",
+   "id": "50",
    "metadata": {},
    "source": [
     "## $(L^{2}-TV)$ Implicit PDHG: using FGP_TV"
@@ -989,7 +989,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ccf2d6d-bbbe-4f55-aabc-13c453bf16da",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1005,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31f6d280",
+   "id": "52",
    "metadata": {},
    "source": [
     "## **Exercise 3: Solution**\n",
@@ -1016,7 +1016,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98231fdf",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,7 +1026,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "796bf380-81c6-424c-9ab1-9af37b863745",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0f699e0",
+   "id": "55",
    "metadata": {},
    "source": [
     "In the above comparison between explicit and implicit TV reconstructions, we may observe some differences in the reconstructions and in the middle line profiles. This is due to a) the number of iterations and b) $\\sigma, \\tau$ values used in both the explicit and implicit setup of the PDHG algorithm. You can try more iterations with different values of $\\sigma$ and $\\tau$ for both cases in order to be sure that converge to the same solution."
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2232e53-a927-461b-9e95-2c9f322257b7",
+   "id": "56",
    "metadata": {},
    "source": [
     "## $(L^{2}-TV)$ Implicit PDHG: using TotalVariation"
@@ -1062,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35b0e04b-4393-46d5-b8a3-bbf6161feeb8",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1077,7 +1077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b78c87bb-9dcf-4d40-b41e-b7118c3ac120",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1096,7 +1096,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f0e9178-110e-4a03-84ff-ef5391e25461",
+   "id": "59",
    "metadata": {},
    "source": [
     "# FBP reconstruction with all the projection angles."
@@ -1104,8 +1104,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "id": "24afa098-da30-4e33-b605-c875b3288767",
+   "execution_count": null,
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1125,7 +1125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40c57ee9-a7a6-4d9c-963b-9757f1086ee8",
+   "id": "61",
    "metadata": {},
    "source": [
     "# Show all reconstructions \n",
@@ -1141,7 +1141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "980d19c1-32d3-4f7f-ba2a-b2260e7be27a",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1157,7 +1157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae6a6825-09ca-45ba-80f2-edf6bb459f4e",
+   "id": "63",
    "metadata": {},
    "source": [
     "## Zoom ROIs"
@@ -1166,7 +1166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e20863a-f0d8-49ba-be86-ee041acccbad",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1183,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "fb10bb8e-bdd7-4945-b291-aa98a0018292",
+   "id": "65",
    "metadata": {},
    "source": [
     "# Conclusions\n",

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d304d2b3",
    "metadata": {},
    "outputs": [],
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "f731d970-d6ce-489a-bf93-7888cc855a60",
    "metadata": {},
    "outputs": [],
@@ -196,12 +196,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "ce2c36aa-1231-4669-9486-197f9332fe2e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"/mnt/materials/SIRF/Fully3D/CIL/Walnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm\""
+    "filename = \"/mnt/share/materials/SIRF/Fully3D/CIL/Walnut/valnut_2014-03-21_643_28/tomo-A/valnut_tomo-A.txrm\""
    ]
   },
   {
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "0fd50459",
    "metadata": {},
    "outputs": [],
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "e6e19c5d-0724-46a2-907c-d9e86b24ee91",
    "metadata": {},
    "outputs": [],
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "3dae73ff-165f-4ac3-990a-e5584a627e9f",
    "metadata": {},
    "outputs": [],
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "4165bcfc-1e28-44ea-bfe3-f85648bc4dc8",
    "metadata": {},
    "outputs": [],
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "e4919986-1aad-4e2d-9af3-68d7b1d685ea",
    "metadata": {},
    "outputs": [],
@@ -501,7 +501,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex1.py"
+    "# %load ./snippets/03_ex1.py\n",
+    "# Setup and run the FBP algorithm\n",
+    "fbp_recon = FBP(ig2D, ag2D,  device = 'gpu')(absorption_data)\n",
+    "\n",
+    "# Setup and run the SIRT algorithm, with  non-negative constraint\n",
+    "x_init = ig2D.allocate()  \n",
+    "sirt = SIRT(initial = x_init, \n",
+    "            operator = A ,\n",
+    "            data = absorption_data, \n",
+    "            constraint = IndicatorBox(lower=0),\n",
+    "            update_objective_interval=100)\n",
+    "sirt.run(300, verbose=1)\n",
+    "sirt_recon = sirt.solution\n",
+    "\n",
+    "# Show reconstructions\n",
+    "show2D([fbp_recon,sirt_recon], \n",
+    "       title = ['FBP reconstruction','SIRT reconstruction'], \n",
+    "       cmap = 'inferno', fix_range=(0,0.05))"
    ]
   },
   {
@@ -645,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "b2879663-a0fe-4a3f-900f-c2cd8ba31226",
    "metadata": {},
    "outputs": [],
@@ -689,7 +706,7 @@
     "\n",
     "# Plot middle line profile\n",
     "show1D([fbp_recon,pdhg_l1.solution], slice_list=[('horizontal_y',int(ig2D.voxel_num_y/2))],\n",
-    "       label = ['FBP','L1 regularisation'], title='Middle Line Profiles')\n"
+    "       dataset_labels = ['FBP','L1 regularisation'], title='Middle Line Profiles')\n"
    ]
   },
   {
@@ -799,7 +816,7 @@
     "\n",
     "# Setup and run PDHG\n",
     "pdhg_tv_explicit = PDHG(f = F, g = G, operator = K,\n",
-    "            update_objective_interval = 200)\n",
+    "            update_objective_interval = 200, check_convergence=False)\n",
     "pdhg_tv_explicit.run(1000, verbose=1)"
    ]
   },
@@ -815,7 +832,7 @@
     "\n",
     "# Plot middle line profile\n",
     "show1D([fbp_recon,pdhg_tv_explicit.solution], slice_list=[('horizontal_y',int(ig2D.voxel_num_y/2))],\n",
-    "       label = ['FBP','TV regularisation'], title='Middle Line Profiles')"
+    "       dataset_labels = ['FBP','TV regularisation'], title='Middle Line Profiles')"
    ]
   },
   {
@@ -909,7 +926,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex2.py"
+    "# %load ./snippets/03_ex2.py\n",
+    "# Define BlockFunction F\n",
+    "alpha_tikhonov = 0.05\n",
+    "f1 = alpha_tikhonov * L2NormSquared()\n",
+    "F = BlockFunction(f1, f2)\n",
+    "\n",
+    "# Setup and run PDHG\n",
+    "pdhg_tikhonov_explicit = PDHG(f = F, g = G, operator = K,\n",
+    "            update_objective_interval = 200)\n",
+    "pdhg_tikhonov_explicit.run(1000, verbose=1)"
    ]
   },
   {
@@ -924,7 +950,7 @@
     "\n",
     "# Plot middle line profile\n",
     "show1D([fbp_recon,pdhg_tikhonov_explicit.solution], slice_list=[('horizontal_y',int(ig2D.voxel_num_y/2))],\n",
-    "       label = ['FBP','Tikhonov regularisation'], title='Middle Line Profiles')"
+    "       dataset_labels = ['FBP','Tikhonov regularisation'], title='Middle Line Profiles')"
    ]
   },
   {
@@ -1020,7 +1046,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %load ./snippets/03_ex3.py"
+    "# %load ./snippets/03_ex3.py\n",
+    "F = 0.5 * L2NormSquared(b=absorption_data)\n",
+    "G = (alpha_tv/ig2D.voxel_size_y) * FGP_TV(max_iteration=100, device='gpu')\n",
+    "K = A\n",
+    "\n",
+    "# Setup and run PDHG\n",
+    "pdhg_tv_implicit_regtk = PDHG(f = F, g = G, operator = K,\n",
+    "            update_objective_interval = 200, check_convergence = False)\n",
+    "pdhg_tv_implicit_regtk.run(1000, verbose=1)"
    ]
   },
   {
@@ -1040,7 +1074,7 @@
     "\n",
     "# Plot middle line profile\n",
     "show1D([pdhg_tv_explicit.solution,pdhg_tv_implicit_regtk.solution], slice_list=[('horizontal_y',int(ig2D.voxel_num_y/2))],\n",
-    "       label = ['TV (explicit)','TV (implicit)'], title='Middle Line Profiles')\n"
+    "       dataset_labels = ['TV (explicit)','TV (implicit)'], title='Middle Line Profiles')\n"
    ]
   },
   {
@@ -1091,7 +1125,7 @@
     "\n",
     "# Plot middle line profile\n",
     "show1D([pdhg_tv_implicit_regtk.solution,pdhg_tv_implicit_cil.solution], slice_list=[('horizontal_y',int(ig2D.voxel_num_y/2))],\n",
-    "       label = ['TV (CCPi-RegTk)','TV (CIL)'], title='Middle Line Profiles')\n"
+    "       dataset_labels = ['TV (CCPi-RegTk)','TV (CIL)'], title='Middle Line Profiles')\n"
    ]
   },
   {
@@ -1104,7 +1138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "24afa098-da30-4e33-b605-c875b3288767",
    "metadata": {},
    "outputs": [],
@@ -1197,19 +1231,11 @@
     "In the following notebook, we are going to present a stochastic version of PDHG, namely **SPDHG** introduced in [Chambolle et al](https://arxiv.org/pdf/1706.04957.pdf) which is extremely useful to reconstruct large datasets, e.g., 3D walnut data. The idea behind SPDHG is to split our initial dataset into smaller chunks and apply  forward and backward operations to these randomly selected subsets of the data. SPDHG has been used for different imaging applications and produces significant computational improvements\n",
     "over the PDHG algorithm, see [Ehrhardt et al](https://arxiv.org/abs/1808.07150) and [Papoutsellis et al](https://arxiv.org/pdf/2102.06126.pdf)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ad6242be-de86-4ae4-9e9a-a8c33dacce58",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cil_24_2_0",
+   "display_name": "cil_demos",
    "language": "python",
    "name": "python3"
   },
@@ -1223,7 +1249,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -28,7 +28,8 @@
     "#                   Gemma Fardell (UKRI-STFC)\n",
     "#                   Laura Murgatroyd (UKRI-STFC)\n",
     "#                   Margaret Duff (UKRI-STFC)\n",
-    "#                   Edoardo Pasca (UKRI-STFC)"
+    "#                   Edoardo Pasca (UKRI-STFC)\n",
+    "#                   Hannah Robarts (UKRI-STFC)"
    ]
   },
   {

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -1215,7 +1215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/03_PDHG.ipynb
+++ b/demos/2_Iterative/03_PDHG.ipynb
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3",
    "metadata": {},
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6",
    "metadata": {},
    "outputs": [],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7",
    "metadata": {},
    "outputs": [],
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "8",
    "metadata": {},
    "outputs": [],
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "16",
    "metadata": {},
    "outputs": [],
@@ -320,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "18",
    "metadata": {},
    "outputs": [],
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "19",
    "metadata": {},
    "outputs": [],
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "22",
    "metadata": {},
    "outputs": [],
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "34",
    "metadata": {},
    "outputs": [],
@@ -905,7 +905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "46",
    "metadata": {},
    "outputs": [],
@@ -1016,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "53",
    "metadata": {},
    "outputs": [],
@@ -1105,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "60",
    "metadata": {},
    "outputs": [],

--- a/demos/2_Iterative/04_SPDHG.ipynb
+++ b/demos/2_Iterative/04_SPDHG.ipynb
@@ -28,7 +28,8 @@
     "#                   Evangelos Papoutsellis (UKRI-STFC)\n",
     "#                   Gemma Fardell (UKRI-STFC)\n",
     "#                   Laura Murgatroyd (UKRI-STFC)  \n",
-    "#                   Margaret Duff (UKRI-STFC)      "
+    "#                   Margaret Duff (UKRI-STFC)\n",
+    "#                   Hannah Robarts (UKRI-STFC)"
    ]
   },
   {

--- a/demos/2_Iterative/04_SPDHG.ipynb
+++ b/demos/2_Iterative/04_SPDHG.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,9 +283,9 @@
     "K = ProjectionOperator(ig2D, ageom_subset)\n",
     "\n",
     "\n",
-    "# Define G (by default the positivity constraint is on)\n",
+    "# Define G (set the constraint that the solution must be positive)\n",
     "alpha = 0.025\n",
-    "G = alpha * FGP_TV()\n"
+    "G = alpha * FGP_TV(nonnegativity=True)\n"
    ]
   },
   {
@@ -577,8 +577,6 @@
     "# Define F and K\n",
     "F = BlockFunction(*f_subsets, f_reg)\n",
     "K = BlockOperator(*A_subsets, Grad_renorm)\n",
-    "\n",
-    "\n",
     "# Setup and run SPDHG for 5 epochs\n",
     "spdhg_explicit = SPDHG(f = F, g = G, operator = K,  \n",
     "                       update_objective_interval = 2 * n_subsets, prob=prob)\n",
@@ -667,18 +665,11 @@
     "\n",
     "\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cil_24_2_0",
+   "display_name": "cil_demos",
    "language": "python",
    "name": "python3"
   },
@@ -692,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/demos/2_Iterative/04_SPDHG.ipynb
+++ b/demos/2_Iterative/04_SPDHG.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/demos/2_Iterative/snippets/03_ex3.py
+++ b/demos/2_Iterative/snippets/03_ex3.py
@@ -4,5 +4,5 @@ K = A
 
 # Setup and run PDHG
 pdhg_tv_implicit_regtk = PDHG(f = F, g = G, operator = K,
-            update_objective_interval = 200)
+            update_objective_interval = 200, check_convergence = False)
 pdhg_tv_implicit_regtk.run(1000, verbose=1)

--- a/demos/2_Iterative/snippets/03_ex3.py
+++ b/demos/2_Iterative/snippets/03_ex3.py
@@ -1,5 +1,5 @@
 F = 0.5 * L2NormSquared(b=absorption_data)
-G = (alpha_tv/ig2D.voxel_size_y) * FGP_TV(max_iteration=100, device='gpu')
+G = (alpha_tv/ig2D.voxel_size_y) * FGP_TV(max_iteration=100, device='gpu', nonnegativity=True)
 K = A
 
 # Setup and run PDHG


### PR DESCRIPTION
01_optimisation_gd_fista

- Change objective function to f in GD to hide deprecation warning
- Suppress deprecation warnings to hide rtol and atol deprecation warning https://github.com/TomographicImaging/CIL/issues/2054
- Update to use nonnegativity in FISTA and PDHG should close https://github.com/TomographicImaging/CIL-Demos/issues/235#issuecomment-2626966432 and https://github.com/TomographicImaging/CIL-Demos/issues/233
PDHG now running for 500 iterations, then plot PDHG primal, dual and gap
![Image](https://github.com/user-attachments/assets/74198401-ef37-4536-9fff-04eaf58622a9)
Then run 500 more iterations and compare the convergence with FISTA
![Image](https://github.com/user-attachments/assets/901fadf3-2669-4f77-8125-2ff4d9fe2cfe)

02_tikhonov_block_framework.ipynb
- show1D labels -> dataset_labels

03_PDHG
- show1D labels -> dataset_labels
- Add check_convergence = False, in code and snippet

04_SPDHG
- Set nonnegativity=True in FGP_TV
- No solution for SPDHG error for now caused by https://github.com/TomographicImaging/CIL/issues/2058

05_laminography_with_TV  looks good!

closes #225 
