### PR TITLE
tidy binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+__pycache__/

--- a/binder/PyData22_deblurring.ipynb
+++ b/binder/PyData22_deblurring.ipynb
@@ -3,14 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e79731ab",
+   "id": "0",
    "metadata": {
-        "jupyter": {
-         "source_hidden": true}
+    "jupyter": {
+     "source_hidden": true
+    }
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
     "#  Copyright 2021 United Kingdom Research and Innovation\n",
     "#  Copyright 2021 The University of Manchester\n",
     "#\n",
@@ -26,12 +26,12 @@
     "#  See the License for the specific language governing permissions and\n",
     "#  limitations under the License.\n",
     "#\n",
-    "#   Authored by:    CIL Developers "
+    "#   Authored by:    CIL Developers"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
+   "id": "1",
    "metadata": {},
    "source": [
     "# Demo 1: Deblurring as an example of inverse problems in CIL"
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e62372-8e1a-460c-a04f-21bf7b7c8634",
+   "id": "2",
    "metadata": {
     "tags": []
    },
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f9dc3c2-390b-4298-b4a8-14280e2037ff",
+   "id": "3",
    "metadata": {},
    "source": [
     "First we import all tools needed:"
@@ -58,11 +58,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1c90a86-a2b5-42c5-bdac-3e77b323b112",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# From CIL\n",
     "from cil.optimisation.algorithms import FISTA\n",
     "from cil.optimisation.operators import BlurringOperator\n",
     "from cil.optimisation.functions import LeastSquares, L2NormSquared, L1Norm, TotalVariation, ZeroFunction\n",
@@ -70,13 +69,12 @@
     "from cil.utilities.display import show2D\n",
     "from cil.optimisation.utilities.callbacks import TextProgressCallback\n",
     "\n",
-    "# Third-party\n",
     "import numpy as np"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4dd73744-23fe-4f64-95d2-a3946c294884",
+   "id": "5",
    "metadata": {},
    "source": [
     "### A. Setting up the direct problem"
@@ -84,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de100599-7643-442e-8e46-c2122beb05f1",
+   "id": "6",
    "metadata": {},
    "source": [
     "CIL comes with a number of test images such as\n",
@@ -101,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e014304-1c11-48bf-aa61-30397a092db6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26a794aa-50b1-47f6-852b-b82c1d4d32ab",
+   "id": "8",
    "metadata": {},
    "source": [
     "We can display the image (first we define a plotting function to use for consistency throughout):"
@@ -120,26 +118,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18dd4c4f-3765-4408-a814-4d146919cc52",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "myshow = lambda image : show2D(image, origin=\"upper\", size=(8,8), fix_range=(0,1))"
+    "def myshow(image, origin=\"upper\", size=(8,8), fix_range=(0,1), **kwargs):\n",
+    "    show2D(image, origin=origin, size=size, fix_range=fix_range, **kwargs)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a908a22b-d686-45dd-b117-5a52dadc24bc",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
-    "myshow(u_true);"
+    "myshow(u_true)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bd26a60f-8afe-4162-b949-1d94563ecd2d",
+   "id": "11",
    "metadata": {},
    "source": [
     "We see that `u_true` is an instance of the CIL `ImageData` class. More image metadata is available in the image's `geometry`:"
@@ -148,20 +147,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9744fe5c-1737-443f-98f3-1966d81b5d9d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
     "print(type(u_true))\n",
-    "print('\\n')\n",
-    "\n",
     "ig = u_true.geometry\n",
     "print(ig)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fa89407d-3a73-4747-9b40-9e561b7c477a",
+   "id": "13",
    "metadata": {},
    "source": [
     "We consider the deblurring problem\n",
@@ -177,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57739e7b-9864-41b8-bbe2-2636da0353ee",
+   "id": "14",
    "metadata": {},
    "source": [
     "To set up the direct problem we specify a **point spread function (PSF)** to blur the image through a convolution:"
@@ -186,13 +183,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6beaf0e1-bbf1-427a-aed9-3349b2ce4e56",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Parameters for point spread function PSF (size and std)\n",
-    "ks          = 5; \n",
-    "ksigma      = 2;\n",
+    "ks          = 5\n",
+    "ksigma      = 2\n",
     "\n",
     "# Create 1D PSF and 2D as outer product, then normalise.\n",
     "w           = np.exp(-np.arange(-(ks-1)/2,(ks-1)/2+1)**2/(2*ksigma**2))\n",
@@ -202,12 +199,12 @@
     "PSF         = PSF/PSF.sum()\n",
     "\n",
     "# Display PSF as image\n",
-    "show2D(PSF, origin=\"upper\", title=\"PSF\", size=(8,8))"
+    "myshow(PSF, title=\"PSF\", fix_range=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "da338dd0-dd4f-4117-987b-2a0611caba16",
+   "id": "16",
    "metadata": {},
    "source": [
     "To be able to apply the blurring to our test image we specify a **BlurringOperator**:"
@@ -216,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a751f696-189e-46c8-a8f6-b863af3a863a",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b02c2c24-76d0-47e8-bf55-8334488af2dd",
+   "id": "18",
    "metadata": {},
    "source": [
     "We apply the blurring operator to the test image and display the blurred image:"
@@ -234,17 +231,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b4fea19-551f-4e48-9f8c-a5fde198e9bc",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
     "u_blur = A.direct(u_true)\n",
-    "myshow(u_blur);"
+    "myshow(u_blur)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "64deaef0-c87f-48ce-a238-9b1e8508e612",
+   "id": "20",
    "metadata": {},
    "source": [
     "We finally add some Gaussian noise to the blurred image:"
@@ -253,17 +250,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ec329c5-36b7-40ee-88f6-2520643ea419",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
     "u_blur_noise = noise.gaussian(u_blur, seed=10, var=0.01)\n",
-    "myshow(u_blur_noise);"
+    "myshow(u_blur_noise)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5a9c505e-4729-4bae-a8d8-48285ef6bf3a",
+   "id": "22",
    "metadata": {},
    "source": [
     "### B. Specifying and solving the inverse problem as optimization problem"
@@ -271,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59a15049-1654-4896-9191-34a57bd4abb2",
+   "id": "23",
    "metadata": {},
    "source": [
     "We formulate the image deblurring problem as an optimization problem to simultaneously fit to the data and enforce regularization on the solution. We use a simple least squares data-fitting term with the blurring operator and try out a few different regularizers $\\Psi(u)$ in the general form optimization problem:"
@@ -279,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a4b311f-bcb2-4c8c-bbf8-2937b62752d1",
+   "id": "24",
    "metadata": {},
    "source": [
     "$$\n",
@@ -294,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46b33c83-e611-42b0-ac4d-2bac4826b79d",
+   "id": "25",
    "metadata": {},
    "source": [
     "We set up a `LeastSquares` function object:"
@@ -303,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2260df8-a5af-4048-81cf-9bf8001dc41b",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "779945a1-cd96-44f2-83bc-fb38e4a5c3a3",
+   "id": "27",
    "metadata": {},
    "source": [
     "`F` is the objective or cost function that we want to minimize. As an example we evaluate it at the zero image:"
@@ -322,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52e1c85c-c5b6-43fc-808c-e99db8d3906b",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df61a4f2-cfcc-4a5b-aa6a-7e7d2f21839a",
+   "id": "29",
    "metadata": {},
    "source": [
     "And for the image of all one values - this apparently has a smaller `F` value so is closer to minimizer:"
@@ -341,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e85161fb-e961-4d57-9f65-d7a702a1f799",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7500ca4-e36f-46cb-afb2-bce012a80087",
+   "id": "31",
    "metadata": {},
    "source": [
     "We set up an instance of the `FISTA` algorithm with just the `F`, specify starting point and how often to print intermediate results:"
@@ -359,18 +356,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4142e2e9-f94d-4a45-b083-3fafbdb5896f",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_LS = FISTA(initial=zero_image, \n",
-    "               f=F, g = ZeroFunction(), \n",
-    "               update_objective_interval=50)"
+    "alg_LS = FISTA(initial=zero_image, f=F, g=ZeroFunction(), update_objective_interval=5)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "67c3f4f0-a964-4638-b040-fba7496e34d4",
+   "id": "33",
    "metadata": {},
    "source": [
     "Once set up, we can then run it for some iterations and inspect the preliminary resulting image. We use a callback to print out our objective function values every `update_objective_interval` and at the end of our iterations. "
@@ -379,17 +374,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b73b688a-430b-4b78-8f00-5f69a433e6a1",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_LS.run(10, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_LS.solution);"
+    "alg_LS.run(10, callbacks=[TextProgressCallback()])\n",
+    "myshow(alg_LS.solution)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ce5a2f6c-9708-479e-b314-7b1e574a32db",
+   "id": "35",
    "metadata": {},
    "source": [
     "Still looking blurry and also more noisy. We try running more iterations (note how the algorithm can be resumed):"
@@ -398,36 +393,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fde484b-2940-452a-9c43-b64919e0361d",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_LS.run(90, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_LS.solution);"
+    "alg_LS.run(10, callbacks=[TextProgressCallback()])\n",
+    "myshow(alg_LS.solution)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "85a62bcf-df67-4455-b9af-ba2577094c82",
+   "id": "37",
    "metadata": {},
    "source": [
-    "The image may be getting a bit sharper but also a lot noisier. If we run even more iterations, this just continues:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60d22780-376c-4ce5-9bf9-113b38b8df4e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "alg_LS.run(400, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_LS.solution);"
+    "The image may be getting a bit sharper but also a lot noisier."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5d4d9c07-ab7a-4e2b-ae2c-28a6672d94fc",
+   "id": "38",
    "metadata": {},
    "source": [
     "We need to use some regularization to handle the noise that is exploding by the inversion. We start by trying classic Tikhonov regularization\n",
@@ -438,16 +422,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53c967ff-e377-4a2f-bcdc-d980dfc9a9d8",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_L2 = 0.2*L2NormSquared()"
+    "G_L2 = 0.2 * L2NormSquared()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "93e46009-ff81-434e-8669-54bd9ebcc710",
+   "id": "40",
    "metadata": {},
    "source": [
     "Another `FISTA` algorithm instance is set up, now with the regularizer passed:"
@@ -456,19 +440,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d716e47a-db62-49fe-92b0-afe674b71019",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_L2 = FISTA(initial=zero_image, \n",
-    "               f=F, \n",
-    "               g=G_L2,\n",
-    "               update_objective_interval=50)"
+    "alg_L2 = FISTA(initial=zero_image, f=F, g=G_L2, update_objective_interval=5)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9d082870-9bfe-4af0-96b5-a429acac7d92",
+   "id": "42",
    "metadata": {},
    "source": [
     "We run some iterations and display the result:"
@@ -477,17 +458,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89e4d901-1be5-412f-b09e-9ce3aa24c176",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_L2.run(100, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_L2.solution);"
+    "alg_L2.run(20, callbacks=[TextProgressCallback()])\n",
+    "myshow(alg_L2.solution)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "319eb999-576d-4dde-bf7e-a7fa03fb1b3b",
+   "id": "44",
    "metadata": {},
    "source": [
     "This is handling the noise better but it is still very smooth, which is the expected behaviour of Tikhonov regularization which introduces smoothing.\n",
@@ -500,16 +481,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a80168f9-9505-4ec6-836b-3b2d5fb4c794",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_L1 = 0.2*L1Norm()"
+    "G_L1 = 0.2 * L1Norm()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6a51258a-ffff-4ff5-9947-816e1143e07b",
+   "id": "46",
    "metadata": {},
    "source": [
     "The `FISTA` instance is set up in the same way as before, with the new `g`:"
@@ -518,19 +499,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f377931b-190f-4b5a-b0a6-7d0fadbc8c39",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_L1 = FISTA(initial=zero_image, \n",
-    "               f=F, \n",
-    "               g=G_L1,\n",
-    "               update_objective_interval=50)"
+    "alg_L1 = FISTA(initial=zero_image, f=F, g=G_L1, update_objective_interval=5)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "823cfbc5-8e63-4690-835c-4da6b85accf4",
+   "id": "48",
    "metadata": {},
    "source": [
     "We run some iterations and display the result:"
@@ -539,17 +517,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3245f5a-ad39-425f-8570-dac00847631c",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_L1.run(200, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_L1.solution);"
+    "alg_L1.run(20, callbacks=[TextProgressCallback()])\n",
+    "myshow(alg_L1.solution)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5115049c-da5f-492d-a050-2eec89b3df5f",
+   "id": "50",
    "metadata": {},
    "source": [
     "This produces a sharper image, with some of the noise reduced, but still very noisy.\n",
@@ -562,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c23e8275-e45c-4a76-8ecb-6b7ea1982ae3",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,30 +550,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1d921df-375d-4161-ab4e-9651c584259f",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_TV = FISTA(initial=zero_image, \n",
-    "               f=F, \n",
-    "               g=G_TV,\n",
-    "               update_objective_interval=50)"
+    "alg_TV = FISTA(initial=zero_image, f=F, g=G_TV, update_objective_interval=1)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7de135de-d463-487a-afe5-6a7978c4665b",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
-    "alg_TV.run(200, callbacks = [TextProgressCallback()])\n",
-    "myshow(alg_TV.solution);"
+    "alg_TV.run(10, callbacks=[TextProgressCallback()])\n",
+    "myshow(alg_TV.solution)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f564d2db-1c80-4b21-abb3-e6dab7da8b40",
+   "id": "54",
    "metadata": {},
    "source": [
     "We see the noise is reduced a lot and the larger bars are well recovered. However the smaller bars are blending together.  One can play with the choice regularization parameter to study the trade-off.\n",
@@ -605,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f12eb4b9-602a-4c3b-bfe6-ff63f2eed6b8",
+   "id": "55",
    "metadata": {},
    "source": [
     "Finally we compare all the reconstructions:"
@@ -614,15 +589,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cbfce90-2f33-4034-9225-d95100e06a3b",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show2D([u_true, u_blur_noise, alg_LS.solution,  alg_L2.solution, alg_L1.solution, alg_TV.solution], \n",
-    "       title=['Original', 'Blurred and noisy', 'Unregularised Least squares', 'L2',  'L1', 'TV'], \n",
-    "       origin=\"upper\", \n",
-    "       fix_range=(0,1), \n",
-    "       num_cols=3);"
+    "myshow([u_true, u_blur_noise, alg_LS.solution,  alg_L2.solution, alg_L1.solution, alg_TV.solution],\n",
+    "       title=['Original', 'Blurred and noisy', 'Unregularised Least squares', 'L2',  'L1', 'TV'],\n",
+    "       num_cols=3)"
    ]
   }
  ],
@@ -634,15 +607,12 @@
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/binder/TomographyReconstruction.ipynb
+++ b/binder/TomographyReconstruction.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32b966bc",
+   "id": "0",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
     "#  Copyright 2021 United Kingdom Research and Innovation\n",
     "#  Copyright 2021 The University of Manchester\n",
     "#\n",
@@ -33,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
+   "id": "1",
    "metadata": {},
    "source": [
     "<h2><center> Tomography Reconstruction using CIL </center></h2>"
@@ -41,7 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e62372-8e1a-460c-a04f-21bf7b7c8634",
+   "id": "2",
    "metadata": {},
    "source": [
     "### In this demo, we reconstruct simulated tomographic data using:\n",
@@ -64,31 +63,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3eff7f8f-df8f-462f-a097-1c2f5079b075",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import libraries\n",
-    "\n",
     "from cil.framework import  AcquisitionGeometry\n",
-    "\n",
     "from cil.optimisation.functions import L2NormSquared, BlockFunction, MixedL21Norm, IndicatorBox\n",
     "from cil.optimisation.operators import GradientOperator, BlockOperator\n",
     "from cil.optimisation.algorithms import PDHG\n",
     "from cil.plugins.astra.operators import ProjectionOperator\n",
     "from cil.plugins.astra.processors import FBP\n",
     "from cil.plugins import TomoPhantom\n",
-    "from cil.utilities.display import show2D, show_geometry\n",
-    "from cil.utilities import noise\n",
+    "from cil.utilities.display import show2D\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
     "import numpy as np"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb26bd6d-d292-4ec0-aaac-00ea093dc45c",
+   "id": "4",
    "metadata": {},
    "source": [
     "We first configure our acquisition geometry, e.g., **2D parallel geometry**. Then, the image geometry is extracted and used to configure our phantom. To create our simulated phantoms, we use the [Tomophantom](https://github.com/dkazanc/TomoPhantom) library."
@@ -97,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98d25e53-a482-4866-b96f-bff02aa54150",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "554f91bb-fa10-4a66-93dc-952afe88ea4f",
+   "id": "6",
    "metadata": {},
    "source": [
     "Next, we create our simulated tomographic data by projecting our noiseless `phantom` to the acquisition space. Using the image geometry `ig` and acquisition geometry `ag`, we define the `ProjectionOperator` with `device=cpu` or `device=gpu`. Finally,  Gaussian noise is added to the noiseless sinogram."
@@ -130,12 +124,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203d1ab6-ecd4-4789-8e02-adf2f1f2c687",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create projection operator using Astra-Toolbox. Available CPU/CPU\n",
-    "A = ProjectionOperator(ig, ag, device = 'cpu')\n",
+    "A = ProjectionOperator(ig, ag, device='cpu')\n",
     "\n",
     "# Create an acquisition data (numerically)\n",
     "sino = A.direct(phantom)\n",
@@ -144,19 +138,19 @@
     "gaussian_var = 0.5\n",
     "gaussian_mean = 0\n",
     "\n",
-    "n1 = np.random.normal(gaussian_mean, gaussian_var, size = ag.shape)\n",
-    "                      \n",
+    "n1 = np.random.normal(gaussian_mean, gaussian_var, size=ag.shape)\n",
+    "\n",
     "noisy_sino = ag.allocate()\n",
     "noisy_sino.fill(n1 + sino.array)\n",
-    "noisy_sino.array[noisy_sino.array<0]=0\n",
+    "noisy_sino.array[noisy_sino.array<0] = 0\n",
     "\n",
     "# Show numerical and noisy sinograms\n",
-    "show2D([phantom, sino, noisy_sino], title = ['Ground Truth','Sinogram','Noisy Sinogram'], num_cols=3, cmap = 'inferno')\n"
+    "show2D([phantom, sino, noisy_sino], title=['Ground Truth','Sinogram','Noisy Sinogram'], num_cols=3, cmap='inferno');"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7f59da59-776e-48f3-81a6-e88188adf078",
+   "id": "8",
    "metadata": {},
    "source": [
     "For our first reconstruction, we use the Filtered BackProjection algorithm, i.e., `FBP` applied to our noisy sinogram `noisy_sino`."
@@ -165,22 +159,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adf9f259-7837-45a0-b87d-a2cfbb510c86",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Setup and run the FBP algorithm\n",
-    "fbp_recon = FBP(ig, ag,  device = 'cpu')(noisy_sino)\n",
+    "fbp_recon = FBP(ig, ag, device='cpu')(noisy_sino)\n",
     "\n",
     "# Show reconstructions\n",
-    "show2D([phantom, fbp_recon], \n",
-    "       title = ['Ground Truth','FBP reconstruction'], \n",
-    "       cmap = 'inferno', fix_range=(0,1.), size=(10,10))"
+    "show2D([phantom, fbp_recon],\n",
+    "       title = ['Ground Truth','FBP reconstruction'],\n",
+    "       cmap = 'inferno', fix_range=(0,1.), size=(10,10));"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0cc1feb8-e1a8-4f9a-a753-89ade7885ea5",
+   "id": "10",
    "metadata": {},
    "source": [
     "In the above reconstruction noise is not penalised. In order to remove noise artifacts, we will use the TotalVariation regularisation as shown in the minimisation problem above.\n",
@@ -226,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a238555-32d7-47ed-ab27-218c6aea653b",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,14 +243,14 @@
     "tau = 1./normK\n",
     "\n",
     "# Setup and run PDHG\n",
-    "pdhg = PDHG(f = f, g = g, operator = K, sigma = sigma, tau = tau,\n",
-    "            update_objective_interval = 50)\n",
-    "pdhg.run(200, verbose=2)"
+    "pdhg = PDHG(f=f, g=g, operator=K, sigma=sigma, tau=tau, update_objective_interval=5)\n",
+    "pdhg.run(40, verbose=2)\n",
+    "#pdhg.run(200, verbose=2) # might take a bit too long to run on binder"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d5c82f2d-4141-443e-b24c-8f3836569918",
+   "id": "12",
    "metadata": {},
    "source": [
     "Finally, we compare the PDHG and FBP reconstructions and plot the middle line profiles."
@@ -265,17 +259,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a0d672f-5369-4851-91b5-9f8ebc5f66fc",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show2D([pdhg.solution,fbp_recon, phantom], title = ['TV regularisation','FBP','Ground Truth'], cmap = 'inferno', num_cols=3, fix_range=(0,1.))\n",
+    "show2D([pdhg.solution, fbp_recon, phantom], title=['TV regularisation','FBP','Ground Truth'], cmap='inferno', num_cols=3, fix_range=(0,1))\n",
     "\n",
     "# Plot middle line profile\n",
     "plt.figure(figsize=(30,15))\n",
-    "plt.plot(phantom.get_slice(horizontal_y = int(N/2)).as_array(), label = 'Ground Truth', linewidth=5)\n",
-    "plt.plot(fbp_recon.get_slice(horizontal_y = int(N/2)).as_array(), label = 'FBP', linewidth=5, linestyle='dashed')\n",
-    "plt.plot(pdhg.solution.get_slice(horizontal_y = int(N/2)).as_array(), label = 'TV', linewidth=5)\n",
+    "plt.plot(phantom.get_slice(horizontal_y=N//2).as_array(), label='Ground Truth', linewidth=5)\n",
+    "plt.plot(fbp_recon.get_slice(horizontal_y=N//2).as_array(), label='FBP', linewidth=5, linestyle='dashed')\n",
+    "plt.plot(pdhg.solution.get_slice(horizontal_y=N//2).as_array(), label='TV', linewidth=5)\n",
     "plt.legend()\n",
     "plt.title('Middle Line Profiles')\n",
     "plt.show()"
@@ -284,21 +278,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cil_binder3",
+   "display_name": "cil_binder",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/binder/TotalGeneralisedVariationInpainting.ipynb
+++ b/binder/TotalGeneralisedVariationInpainting.ipynb
@@ -270,20 +270,31 @@
     "\n",
     "# Setup and run the PDHG algorithm\n",
     "pdhg = PDHG(f=f, g=g, operator=K, sigma=sigma, tau=tau, update_objective_interval=5)\n",
-    "pdhg.run(20, verbose=2)\n",
-    "#pdhg.run(400, verbose=2) # might take a bit too long to run on binder"
+    "iterations = 20\n",
+    "#iterations = 400 # might take a bit too long to run on binder\n",
+    "pdhg.run(iterations, verbose=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "Note that we only run 20 iterations due to slow runtime on binder, so artefacts will still be visible.\n",
+    "\n",
+    "If you run this notebook locally, it will be much quicker — try using 400 iterations to almost completely recover the original image."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
     "show_images = [data, noisy_data, pdhg.solution.get_item(0),\n",
     "               (pdhg.solution.get_item(0)-data).abs()+0.1]\n",
-    "title_image = [\"Ground Truth\", \"Corrupted Data\", \"TGV\", \"Absolute difference\"]\n",
+    "title_image = [\"Ground Truth\", \"Corrupted Data\", f\"TGV ({iterations} iters)\", \"Absolute difference\"]\n",
     "\n",
     "fig = plt.figure(figsize=(20, 20))\n",
     "grid = AxesGrid(fig, 111, nrows_ncols=(2, 2), axes_pad=0.45)\n",

--- a/binder/TotalGeneralisedVariationInpainting.ipynb
+++ b/binder/TotalGeneralisedVariationInpainting.ipynb
@@ -3,14 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86bbc581",
+   "id": "0",
    "metadata": {
-        "jupyter": {
-         "source_hidden": true}
+    "jupyter": {
+     "source_hidden": true
+    }
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
     "#  Copyright 2021 United Kingdom Research and Innovation\n",
     "#  Copyright 2021 The University of Manchester\n",
     "#\n",
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
+   "id": "1",
    "metadata": {},
    "source": [
     "<h2><center> Total Generalised Variation Inpainting </center></h2>"
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e62372-8e1a-460c-a04f-21bf7b7c8634",
+   "id": "2",
    "metadata": {},
    "source": [
     "### In this demo, we solve the following minimisation problem:\n",
@@ -71,12 +71,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dde8d044-8476-49c8-85f0-bb113e02910b",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import libraries\n",
-    "from cil.framework import ImageGeometry\n",
     "from cil.utilities import dataexample, noise\n",
     "from cil.optimisation.operators import MaskOperator, BlockOperator, SymmetrisedGradientOperator, \\\n",
     "                                GradientOperator, ZeroOperator, IdentityOperator, ChannelwiseOperator\n",
@@ -87,14 +85,12 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from PIL import Image\n",
-    "from PIL import ImageFont\n",
-    "from PIL import ImageDraw"
+    "from PIL import Image, ImageFont, ImageDraw"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "66bff487-94bf-445c-952b-e347ca436ff3",
+   "id": "4",
    "metadata": {},
    "source": [
     "We first load the _RAINBOW_ image from the dataexample class and create a text inpainted domain using the **Pillow** library."
@@ -103,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34fe6ea7-9f47-42d3-a99a-ac5b8a6cd2d6",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e7310c2",
+   "id": "6",
    "metadata": {},
    "source": [
     "Note: If you are on a windows machine it is possible that you do not have access to the font file \"DejaVuSerif.tff\". If you get an error on line `font = ImageFont.truetype('DejaVuSerif.ttf', 50)` then we recommend that you download the files from https://www.fontsquirrel.com/fonts/dejavu-serif, place the \"DejaVuSerif.tff\" file in the same folder as this notebook and change the line to be `font = ImageFont.truetype('./DejaVuSerif.ttf', 50)`."
@@ -125,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74febdda-5b8f-42dd-8d57-7314a25cd998",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbcc5978-76ad-45d7-81a1-f22f39930d80",
+   "id": "8",
    "metadata": {},
    "source": [
     "Then, we create a mask array, based on the missing text and applied it to the Red, Green and Blue channels of the coloured image using the **ChannelwiseOperator**. Finally, salt and pepper noise is added to create the `noisy_data`."
@@ -158,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd0bd99c-04d0-454a-ad95-806845f4fc93",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +169,7 @@
     "\n",
     "# Add salt and pepper noise\n",
     "noisy_data = noise.saltnpepper(data_inpainted, amount=0.01, seed = 10)\n",
-    "noisy_data = MO.direct(noisy_data) \n",
+    "noisy_data = MO.direct(noisy_data)\n",
     "\n",
     "f, ax = plt.subplots(1,2, figsize=(15,10))\n",
     "ax[0].imshow(mask.as_array())\n",
@@ -185,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2610c194-d35a-4bf3-ba09-e43cb9190cf5",
+   "id": "10",
    "metadata": {},
    "source": [
     "In order to solve [(1)](#tgv_reg), we use the  **Primal-Dual Hybrid Gradient (PDHG)** algorithm, introduced in [ChambollePock](https://link.springer.com/article/10.1007/s10851-010-0251-1). We setup and run the PDHG algorithm using the Total Generalised variation regularisation. We need to write the minimisation problem:\n",
@@ -241,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b44c7c1-b09d-4f97-88ee-6e8ae382d502",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,10 +248,10 @@
     "# Define BlockFunction f\n",
     "f1 = L1Norm(b=noisy_data)\n",
     "f2 = alpha * MixedL21Norm()\n",
-    "f3 = beta * MixedL21Norm() \n",
-    "f = BlockFunction(f1, f2, f3)         \n",
+    "f3 = beta * MixedL21Norm()\n",
+    "f = BlockFunction(f1, f2, f3)\n",
     "\n",
-    "# Define function g \n",
+    "# Define function g\n",
     "g = ZeroFunction()\n",
     "\n",
     "# Define BlockOperator K\n",
@@ -273,36 +269,31 @@
     "tau = 1./(sigma*normK**2)\n",
     "\n",
     "# Setup and run the PDHG algorithm\n",
-    "pdhg = PDHG(f=f,g=g,operator=K,\n",
-    "            sigma=sigma, tau=tau,\n",
-    "            update_objective_interval = 100)\n",
-    "pdhg.run(500,verbose = 2)      "
+    "pdhg = PDHG(f=f, g=g, operator=K, sigma=sigma, tau=tau, update_objective_interval=5)\n",
+    "pdhg.run(20, verbose=2)\n",
+    "#pdhg.run(400, verbose=2) # might take a bit too long to run on binder"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e035d63-22e1-43d7-8fed-2d22f5de6531",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_images = [data, noisy_data, pdhg.solution.get_item(0), \n",
+    "show_images = [data, noisy_data, pdhg.solution.get_item(0),\n",
     "               (pdhg.solution.get_item(0)-data).abs()+0.1]\n",
-    "title_image = [\"Ground Truth\", \"Corrupted Data\", \"TGV\", \"Absolute difference\"]                   \n",
-    "\n",
+    "title_image = [\"Ground Truth\", \"Corrupted Data\", \"TGV\", \"Absolute difference\"]\n",
     "\n",
     "fig = plt.figure(figsize=(20, 20))\n",
-    "grid = AxesGrid(fig, 111,\n",
-    "                nrows_ncols=(2, 2),\n",
-    "                axes_pad=0.45)\n",
+    "grid = AxesGrid(fig, 111, nrows_ncols=(2, 2), axes_pad=0.45)\n",
     "\n",
     "k = 0\n",
     "for ax in grid:\n",
-    "        \n",
     "    im = ax.imshow(show_images[k].as_array())\n",
-    "    ax.set_title(title_image[k],fontsize=25)    \n",
+    "    ax.set_title(title_image[k],fontsize=25)\n",
     "    k+=1\n",
-    "    \n",
+    "\n",
     "plt.show()"
    ]
   }
@@ -315,15 +306,12 @@
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/binder/TotalVariationDeblurring.ipynb
+++ b/binder/TotalVariationDeblurring.ipynb
@@ -3,14 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b929b3d4",
+   "id": "0",
    "metadata": {
-        "jupyter": {
-         "source_hidden": true}
+    "jupyter": {
+     "source_hidden": true
+    }
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
     "#  Copyright 2021 United Kingdom Research and Innovation\n",
     "#  Copyright 2021 The University of Manchester\n",
     "#\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
+   "id": "1",
    "metadata": {},
    "source": [
     "<h2><center> Total variation deblurring </center></h2>"
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e62372-8e1a-460c-a04f-21bf7b7c8634",
+   "id": "2",
    "metadata": {},
    "source": [
     "### In this demo, we solve the following minimisation problem:\n",
@@ -62,14 +62,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1c90a86-a2b5-42c5-bdac-3e77b323b112",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import libraries\n",
     "from cil.optimisation.algorithms import FISTA\n",
     "from cil.optimisation.operators import BlurringOperator\n",
-    "from cil.optimisation.functions import L2NormSquared, LeastSquares, TotalVariation\n",
+    "from cil.optimisation.functions import LeastSquares, TotalVariation\n",
     "from cil.utilities import dataexample, noise\n",
     "from cil.utilities.display import show2D\n",
     "\n",
@@ -78,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de100599-7643-442e-8e46-c2122beb05f1",
+   "id": "4",
    "metadata": {},
    "source": [
     "We load an image from the `dataexample` class. In this demo, we use the `SHAPES` image. \n",
@@ -96,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f698f450-ad64-43fb-8a66-c07aedfcd41f",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da338dd0-dd4f-4117-987b-2a0611caba16",
+   "id": "6",
    "metadata": {},
    "source": [
     "Next, we define a **Point Spread Function (PSF)** and the BlurringOperator. To obtain our blurred and noisy image, we create the blurred image using the BlurringOperator and Gaussian noise is added with relatively small variance."
@@ -118,13 +117,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a05b493-0d5f-4905-b273-6c9092d7661c",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Parameters for point spread function PSF (size and std)\n",
-    "ks          = 5; \n",
-    "ksigma      = 2;\n",
+    "ks          = 5\n",
+    "ksigma      = 2\n",
     "\n",
     "# Create 1D PSF and 2D as outer product, then normalise.\n",
     "w           = np.exp(-np.arange(-(ks-1)/2,(ks-1)/2+1)**2/(2*ksigma**2))\n",
@@ -141,12 +140,12 @@
     "blurred_noisy = noise.gaussian(BOP.direct(data), seed = 10, var = 0.0001)\n",
     "\n",
     "# Show blurred and noisy image\n",
-    "show2D(blurred_noisy, origin=\"upper\", title=\"Blurred+Noisy\", size=(10,10))"
+    "show2D(blurred_noisy, origin=\"upper\", title=\"Blurred+Noisy\", size=(10,10));"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e407d6e9-3389-4a92-aec3-b2a54665a143",
+   "id": "8",
    "metadata": {},
    "source": [
     "Finally, we setup and run the FISTA algorithm using the Total variation regularisation. We can use either:\n",
@@ -160,30 +159,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79af7215-1bcf-4694-a852-c9fde34be93f",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Setup and run FISTA algorithm \n",
+    "# Setup and run FISTA algorithm\n",
     "alpha = 0.05\n",
     "G = alpha * TotalVariation(max_iteration=10)\n",
     "F = LeastSquares(BOP, blurred_noisy)\n",
     "\n",
-    "fista = FISTA(initial = ig.allocate(0), f = F, g = G, \n",
-    "              update_objective_interval = 50)\n",
-    "fista.run(200)  "
+    "fista = FISTA(initial=ig.allocate(0), f=F, g=G, update_objective_interval=5)\n",
+    "fista.run(20)\n",
+    "#fista.run(200) # might take a bit too long to run on binder"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d02afdc-6f73-4128-9518-fccf34b9468f",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show2D([data, blurred_noisy, fista.solution], \n",
-    "       title=['Ground truth', 'Noisy Data (Gaussian)', 'Deblurred'], \n",
-    "       origin=\"upper\", num_cols=3)"
+    "show2D([data, blurred_noisy, fista.solution], title=['Ground truth', 'Noisy Data (Gaussian)', 'Deblurred'], origin=\"upper\", num_cols=3);"
    ]
   }
  ],
@@ -195,15 +192,12 @@
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/binder/TotalVariationDenoising.ipynb
+++ b/binder/TotalVariationDenoising.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59c55522",
+   "id": "0",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
     "#  Copyright 2021 United Kingdom Research and Innovation\n",
     "#  Copyright 2021 The University of Manchester\n",
     "#\n",
@@ -32,7 +31,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d4e368f-180a-4cf5-b6ee-dbea67c5a0c4",
+   "id": "1",
    "metadata": {},
    "source": [
     "<h2><center> Total variation denoising </center></h2>"
@@ -40,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e62372-8e1a-460c-a04f-21bf7b7c8634",
+   "id": "2",
    "metadata": {},
    "source": [
     "### In this demo, we solve the following minimisation problem:\n",
@@ -60,11 +59,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1c90a86-a2b5-42c5-bdac-3e77b323b112",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import libraries\n",
     "from cil.optimisation.functions import TotalVariation\n",
     "from cil.utilities import dataexample, noise\n",
     "from cil.utilities.display import show2D"
@@ -72,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fba6fa3c-9411-44d4-8681-5081f4ceac79",
+   "id": "4",
    "metadata": {},
    "source": [
     "We load an image from the `dataexample` class. In this demo, we use the `CAMERA` image. \n",
@@ -90,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c366197-2088-4af0-b20f-62f33182ee0a",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,12 +96,12 @@
     "data = dataexample.CAMERA.get()\n",
     "\n",
     "# Add gaussian noise\n",
-    "noisy_data = noise.gaussian(data, seed = 10, var = 0.02)"
+    "noisy_data = noise.gaussian(data, seed=10, var=0.02)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c7980e9a-e5db-48ce-a680-8bfc40a0cf79",
+   "id": "6",
    "metadata": {},
    "source": [
     "We use the **proximal method** of the **TotalVariation** class which implements the FGP algorithm."
@@ -112,25 +110,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51149b58-ea03-4fdd-9eae-3fb75a243f97",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
     "alpha = 0.15\n",
-    "TV = alpha * TotalVariation(max_iteration=100)\n",
+    "TV = alpha * TotalVariation(10)\n",
+    "#TV = alpha * TotalVariation(100) # might take a bit too long to run on binder\n",
     "proxTV = TV.proximal(noisy_data, tau=1.0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd01ebdd-7925-4496-8e0e-d5da51e817e4",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show2D([data, noisy_data, proxTV], \n",
-    "       title=['Ground truth', 'Noisy Data (Gaussian)', 'Total variation'], \n",
-    "       origin=\"upper\", num_cols=3)"
+    "show2D([data, noisy_data, proxTV], title=[\"Ground truth\", \"Noisy Data (Gaussian)\", \"Total variation\"], origin='upper', num_cols=3);"
    ]
   }
  ],
@@ -142,15 +139,12 @@
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,7 +12,7 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
-name: cil_binder4
+name: cil_binder
 channels:
   - conda-forge
   - https://software.repos.intel.com/python/conda

--- a/binder/index.ipynb
+++ b/binder/index.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b49fe429-9dd4-4350-9e7f-332d7b1c1108",
+   "id": "0",
    "metadata": {},
    "source": [
     "## Core Imaging Library demos\n",
@@ -23,15 +23,12 @@
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
cleanup & major speedup

- reduce runtime to <10mins per binder notebook (mybinder.org VMs are sloooow nowadays)
- follow-up to #256

demo: [binder:TomographicImaging/CIL-Demos@tidy-binder](https://mybinder.org/v2/gh/TomographicImaging/CIL-Demos/tidy-binder?urlpath=lab/tree/binder%2Findex.ipynb)