### PR TITLE
Tigre parallel beam euler angles example

### DIFF
--- a/misc/tigre_tilted_parallel.py
+++ b/misc/tigre_tilted_parallel.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 
 from cil.utilities.display import show_geometry, show2D
 from cil.framework import  AcquisitionGeometry
-from cil.framework.labels import AngleUnit
 
 from cil.plugins.tigre import CIL2TIGREGeometry
 import tigre
@@ -23,13 +22,10 @@ lines[2:4,2:14,10:14] = 1
 ig = ImageGeometry(lines.shape[1],lines.shape[2],lines.shape[0])
 lines = ImageData(lines, geometry=ig)
 show2D(lines,
-    #    ['X', 'Y', 'Z'], 
        slice_list=[(0, int(lines.shape[0]/2)), (1, int(lines.shape[1]/2)), (2, 3)], 
        num_cols=3)
-    #    origin='lower-left')
 
-
-# %%
+# %% Start with an untilted geometry
 untilted_rotation_axis = np.array([0, 0, 1])
 angles = np.arange(0,360,1)
 ag_untilted = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=untilted_rotation_axis)\
@@ -37,13 +33,14 @@ ag_untilted = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=unti
     .set_panel(lines.shape[1:3])
 show_geometry(ag_untilted)
 
-# %%
+# %% Create projections
 A = ProjectionOperator(ig, ag_untilted)
 proj = A.direct(lines) 
 show2D([proj.array[0], proj.array[90], proj.array[180]], 
        ['0', r'$\pi/2$', r'$\pi$'],
        num_cols=3)
-# %%
+
+# %% Now create a tilted geometry
 tilt = 20 # degrees
 tilt_rad = np.deg2rad(tilt)
 tilt_direction = np.array([1, 0, 0])
@@ -57,36 +54,18 @@ ag = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=tilted_rotati
     .set_panel(lines.shape[1:3])
 show_geometry(ag)
 
-
-
-# %%
-tg, angles = CIL2TIGREGeometry.getTIGREGeometry(ig, ag)
-
-tg.check_geo(angles)
-tg.cast_to_single()
-plt.plot(tg.angles,'--')
-# tg.rotDetector = np.array((0.0, 0.0, 0.0))
-
-from _Ax import _Ax_ext as Ax
-proj = Ax(lines.as_array(), tg, tg.angles,
-                      "interpolated", "parallel")
-show2D([proj[0], proj[90], proj[180]], 
-       ['0', r'$\pi/2$', r'$\pi$'],
-       num_cols=3)
-
-# %%
+# %% Create the projections
 A = ProjectionOperator(ig, ag)
 
 plt.plot(A.tigre_geom.angles)
-proj = A.direct(lines) # this doesn't currently work in CIL with parallel geometry and tilted rotation axis
-# show2D(proj, slice_list=[(0,0),(0,1),(0,2)])
-
+proj = A.direct(lines) 
 
 show2D([proj.array[0], proj.array[90], proj.array[180]], 
        ['0', r'$\pi/2$', r'$\pi$'],
        num_cols=3)
+# The sample is tilted towards the beam. Check the angle at 90 degres rotation
 
-# %% using tigre directly
+# %% Check how it looks using tigre directly
 geo = tigre.geometry()
 geo.DSO = 5
 geo.DSD = 5
@@ -99,10 +78,11 @@ geo.dVoxel = geo.sVoxel/geo.nVoxel
 geo.mode = "parallel"
 geo.accuracy = 0.5
 
-anglesY = -(np.deg2rad(ag.angles)  + np.pi/2)
+# conversion to tigre angles
+angles_t = -(np.deg2rad(ag.angles)  + np.pi/2)
 
 euler_angles_old = []
-for angle in anglesY:
+for angle in angles_t:
     R1 = R.from_euler("z", angle, degrees=False)
     combined = rotation_matrix * R1
     euler = combined.as_euler("ZYZ", degrees=False)

--- a/misc/tigre_tilted_parallel.py
+++ b/misc/tigre_tilted_parallel.py
@@ -16,13 +16,13 @@ from cil.framework import ImageData, ImageGeometry, AcquisitionGeometry
 from cil.plugins.tigre import ProjectionOperator
 # %% Create phantom
 lines = np.zeros((6, 16,16), dtype=np.float32)
-lines[2:4,2:14,2:6] = 1
+lines[2:4,2:14,2:6] = 0.5
 lines[2:4,2:14,10:14] = 1
 
 ig = ImageGeometry(lines.shape[1],lines.shape[2],lines.shape[0])
 lines = ImageData(lines, geometry=ig)
 show2D(lines,
-       slice_list=[(0, int(lines.shape[0]/2)), (1, int(lines.shape[1]/2)), (2, 3)], 
+       slice_list=[(0, int(lines.shape[0]/2)), (1, int(lines.shape[1]/2)), (2, 3)],
        num_cols=3)
 
 # %% Start with an untilted geometry
@@ -30,7 +30,7 @@ untilted_rotation_axis = np.array([0, 0, 1])
 angles = np.arange(0,360,1)
 ag_untilted = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=untilted_rotation_axis)\
     .set_angles(angles)\
-    .set_panel(lines.shape[1:3])
+    .set_panel(lines.shape[1:3],origin='top-left')
 show_geometry(ag_untilted)
 
 # %% Create projections
@@ -51,13 +51,12 @@ tilted_rotation_axis = rotation_matrix.apply(untilted_rotation_axis)
 angles = np.arange(0,360,1)
 ag = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=tilted_rotation_axis)\
     .set_angles(angles)\
-    .set_panel(lines.shape[1:3])
+    .set_panel(lines.shape[1:3],origin='top-left')
 show_geometry(ag)
 
 # %% Create the projections
 A = ProjectionOperator(ig, ag)
 
-plt.plot(A.tigre_geom.angles)
 proj = A.direct(lines) 
 
 show2D([proj.array[0], proj.array[90], proj.array[180]], 
@@ -68,7 +67,7 @@ show2D([proj.array[0], proj.array[90], proj.array[180]],
 # %% Check how it looks using tigre directly
 geo = tigre.geometry()
 geo.DSO = 5
-geo.DSD = 5
+geo.DSD = 5000 #move detector outside of object otherwise it clips
 geo.nDetector = np.array([16, 16])
 geo.dDetector = np.array([1, 1]) 
 geo.sDetector = geo.nDetector * geo.dDetector
@@ -81,18 +80,17 @@ geo.accuracy = 0.5
 # conversion to tigre angles
 angles_t = -(np.deg2rad(ag.angles)  + np.pi/2)
 
-euler_angles_old = []
-for angle in angles_t:
-    R1 = R.from_euler("z", angle, degrees=False)
-    combined = rotation_matrix * R1
-    euler = combined.as_euler("ZYZ", degrees=False)
-    euler_angles_old.append(euler)
+R_tilt = R.from_euler("Y", tilt_rad, degrees=False)
+euler_angles = []
 
+for i, theta in enumerate(angles_t):
+    R_rot = R.from_euler("Z",theta)
+    R_Full = R_rot * R_tilt
+    euler = R_Full.as_euler("ZYZ")
+    euler_angles.append(euler)
 
-plt.plot(euler_angles_old)
-
-euler_angles_old = np.array(euler_angles_old, dtype=np.float32) 
-out = tigre.Ax(lines.array.astype(np.float32), geo, euler_angles_old, "interpolated")
+euler_angles = np.array(euler_angles, dtype=np.float32) 
+out = tigre.Ax(lines.array, geo, euler_angles, "interpolated")
 
 show2D([out[0], out[90], out[180]], 
        ['0', r'$\pi/2$', r'$\pi$'],

--- a/misc/tigre_tilted_parallel.py
+++ b/misc/tigre_tilted_parallel.py
@@ -1,0 +1,119 @@
+# Test creating a tilted reconstruction geometry in tigre using Euler angles
+# %%
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+import matplotlib.pyplot as plt
+
+from cil.utilities.display import show_geometry, show2D
+from cil.framework import  AcquisitionGeometry
+from cil.framework.labels import AngleUnit
+
+from cil.plugins.tigre import CIL2TIGREGeometry
+import tigre
+
+
+from cil.framework import ImageData, ImageGeometry, AcquisitionGeometry
+from cil.plugins.tigre import ProjectionOperator
+# %% Create phantom
+lines = np.zeros((6, 16,16), dtype=np.float32)
+lines[2:4,2:14,2:6] = 1
+lines[2:4,2:14,10:14] = 1
+
+ig = ImageGeometry(lines.shape[1],lines.shape[2],lines.shape[0])
+lines = ImageData(lines, geometry=ig)
+show2D(lines,
+    #    ['X', 'Y', 'Z'], 
+       slice_list=[(0, int(lines.shape[0]/2)), (1, int(lines.shape[1]/2)), (2, 3)], 
+       num_cols=3)
+    #    origin='lower-left')
+
+
+# %%
+untilted_rotation_axis = np.array([0, 0, 1])
+angles = np.arange(0,360,1)
+ag_untilted = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=untilted_rotation_axis)\
+    .set_angles(angles)\
+    .set_panel(lines.shape[1:3])
+show_geometry(ag_untilted)
+
+# %%
+A = ProjectionOperator(ig, ag_untilted)
+proj = A.direct(lines) 
+show2D([proj.array[0], proj.array[90], proj.array[180]], 
+       ['0', r'$\pi/2$', r'$\pi$'],
+       num_cols=3)
+# %%
+tilt = 20 # degrees
+tilt_rad = np.deg2rad(tilt)
+tilt_direction = np.array([1, 0, 0])
+beam_direction = np.array([0, 1, 0])
+
+rotation_matrix = R.from_rotvec(tilt_rad * tilt_direction)
+tilted_rotation_axis = rotation_matrix.apply(untilted_rotation_axis)
+angles = np.arange(0,360,1)
+ag = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=tilted_rotation_axis)\
+    .set_angles(angles)\
+    .set_panel(lines.shape[1:3])
+show_geometry(ag)
+
+
+
+# %%
+tg, angles = CIL2TIGREGeometry.getTIGREGeometry(ig, ag)
+
+tg.check_geo(angles)
+tg.cast_to_single()
+plt.plot(tg.angles,'--')
+# tg.rotDetector = np.array((0.0, 0.0, 0.0))
+
+from _Ax import _Ax_ext as Ax
+proj = Ax(lines.as_array(), tg, tg.angles,
+                      "interpolated", "parallel")
+show2D([proj[0], proj[90], proj[180]], 
+       ['0', r'$\pi/2$', r'$\pi$'],
+       num_cols=3)
+
+# %%
+A = ProjectionOperator(ig, ag)
+
+plt.plot(A.tigre_geom.angles)
+proj = A.direct(lines) # this doesn't currently work in CIL with parallel geometry and tilted rotation axis
+# show2D(proj, slice_list=[(0,0),(0,1),(0,2)])
+
+
+show2D([proj.array[0], proj.array[90], proj.array[180]], 
+       ['0', r'$\pi/2$', r'$\pi$'],
+       num_cols=3)
+
+# %% using tigre directly
+geo = tigre.geometry()
+geo.DSO = 5
+geo.DSD = 5
+geo.nDetector = np.array([16, 16])
+geo.dDetector = np.array([1, 1]) 
+geo.sDetector = geo.nDetector * geo.dDetector
+geo.nVoxel = np.array(lines.shape)
+geo.sVoxel = np.array(lines.shape)
+geo.dVoxel = geo.sVoxel/geo.nVoxel
+geo.mode = "parallel"
+geo.accuracy = 0.5
+
+anglesY = -(np.deg2rad(ag.angles)  + np.pi/2)
+
+euler_angles_old = []
+for angle in anglesY:
+    R1 = R.from_euler("z", angle, degrees=False)
+    combined = rotation_matrix * R1
+    euler = combined.as_euler("ZYZ", degrees=False)
+    euler_angles_old.append(euler)
+
+
+plt.plot(euler_angles_old)
+
+euler_angles_old = np.array(euler_angles_old, dtype=np.float32) 
+out = tigre.Ax(lines.array.astype(np.float32), geo, euler_angles_old, "interpolated")
+
+show2D([out[0], out[90], out[180]], 
+       ['0', r'$\pi/2$', r'$\pi$'],
+       num_cols=3)


### PR DESCRIPTION
Example of using tigre tilted rotation axis geometry (https://github.com/TomographicImaging/CIL/pull/2238) to create projections from a phantom